### PR TITLE
Type export

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,3 @@
 export type { Config } from './lib/config';
 export type { Message } from './lib/message';
-export * from './lib/json_object';
 export * from './lib/sqs_processor';

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-export * from './lib/config';
+export type { Config } from './lib/config';
+export type { Message } from './lib/message';
 export * from './lib/json_object';
-export * from './lib/message';
 export * from './lib/sqs_processor';


### PR DESCRIPTION
This PR adds `type` keyword to the export line for type only files.

Without the explicit type export, typescript would treat the module as a concrete module and attempt to load it in the compiled javascript.  However, since `config` and `message` are both type-only files, this results an error when the package is loaded.